### PR TITLE
Changed css injection order of material ui

### DIFF
--- a/packages/ui/components/Drawer.module.css
+++ b/packages/ui/components/Drawer.module.css
@@ -58,7 +58,7 @@
 
 .inviteBtn {
   border-radius: 8px;
-  background: #9324f8;
+  background: #9324f8 !important;
   color: white;
   width: 204px;
   height: 50px;

--- a/packages/ui/components/Drawer.module.css
+++ b/packages/ui/components/Drawer.module.css
@@ -57,25 +57,25 @@
 }
 
 .inviteBtn {
-  border-radius: 8px !important;
-  background: #9324f8 !important;
-  color: white !important;
-  width: 204px !important;
-  height: 50px !important;
-  align-self: center !important;
-  text-transform: none !important;
-  font-family: "Inter" !important;
-  font-weight: bold !important;
-  font-size: 16px !important;
-  letter-spacing: 0.5px !important;
+  border-radius: 8px;
+  background: #9324f8;
+  color: white;
+  width: 204px;
+  height: 50px;
+  align-self: center;
+  text-transform: none;
+  font-family: "Inter";
+  font-weight: bold;
+  font-size: 16px;
+  letter-spacing: 0.5px;
 }
 
 .rules {
-  margin-top: 26px !important;
-  color: white !important;
-  font-family: "Inter" !important;
-  font-size: 16px !important;
-  letter-spacing: 0.5px !important;
+  margin-top: 26px;
+  color: white;
+  font-family: "Inter";
+  font-size: 16px;
+  letter-spacing: 0.5px;
   text-align: center;
   text-underline-offset: 2px;
 }

--- a/packages/ui/components/MainNav.module.css
+++ b/packages/ui/components/MainNav.module.css
@@ -3,7 +3,7 @@
 }
 
 .mainContent {
-  background-color: white !important;
+  background-color: white;
   width: 100%;
   min-height: -webkit-fill-available;
   flex-grow: 1;

--- a/packages/ui/components/MainNavMobile.module.css
+++ b/packages/ui/components/MainNavMobile.module.css
@@ -1,6 +1,6 @@
 .hamburger {
   cursor: pointer;
-  font-size: 2.5rem !important;
+  font-size: 2.5rem;
   position: fixed;
   right: 0px;
   color: #452056;

--- a/packages/ui/components/transitions.module.css
+++ b/packages/ui/components/transitions.module.css
@@ -1,17 +1,17 @@
 .myNodeEnter {
-  width: 284px !important;
+  width: 284px;
 }
 
 .myNodeEnterActive {
-  width: 284px !important;
+  width: 284px;
   transition: width 200ms cubic-bezier(0.82, 0.085, 0.395, 0.895);
 }
 
 .myNodeExit {
-  width: 0px !important;
+  width: 0px;
 }
 
 .myNodeExitActive {
-  width: 0px !important;
+  width: 0px;
   transition: width 200ms cubic-bezier(0.82, 0.085, 0.395, 0.895);
 }

--- a/packages/ui/pages/_app.js
+++ b/packages/ui/pages/_app.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Head from "next/head";
-import { ThemeProvider } from "@material-ui/core/styles";
+import { StylesProvider, ThemeProvider } from "@material-ui/core/styles";
 import CssBaseline from "@material-ui/core/CssBaseline";
 import theme from "../src/theme";
 import { useRouter } from "next/router";
@@ -26,7 +26,7 @@ function MyApp({ Component, pageProps }) {
   }, []);
 
   return (
-    <React.Fragment>
+    <StylesProvider injectFirst>
       <Head>
         <title>daoOS</title>
         <meta
@@ -55,7 +55,7 @@ function MyApp({ Component, pageProps }) {
           <Component {...pageProps} />
         )}
       </ThemeProvider>
-    </React.Fragment>
+    </StylesProvider>
   );
 }
 

--- a/packages/ui/pages/_document.js
+++ b/packages/ui/pages/_document.js
@@ -11,6 +11,7 @@ export default class MyDocument extends Document {
         <Head>
           {/* PWA primary color */}
           <meta name="theme-color" content={theme.palette.primary.main} />
+          {this.props.materialStyle}
           <style
             type="text/css"
             dangerouslySetInnerHTML={{ __html: mediaStyles }}
@@ -70,10 +71,6 @@ MyDocument.getInitialProps = async (ctx) => {
 
   return {
     ...initialProps,
-    // Styles fragment is rendered after the app and page rendering finish.
-    styles: [
-      ...React.Children.toArray(initialProps.styles),
-      sheets.getStyleElement(),
-    ],
+    materialStyle: sheets.getStyleElement(),
   };
 };


### PR DESCRIPTION
Changed css injection order of material ui to inject its styles first. Because it's injected first, it is given lower specificity and the `!important` overrides are no longer needed. This way we are not forced to use the material ui css-in-js classes system. We can now use css modules without specificity overrides.

Acceptance criteria:
* There are no visual or functional changes in this PR, it's a QOL feature. Just confirm this branch is identical to the UI and functionality of `dashboard-ui` branch (i.e nothing broke).